### PR TITLE
feat/PLAY-34 Update readme for Android SDK demo repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
 # About
 
-This is a sample application that demonstrates how to integrate Flowplayer Android SDK in your Android project.
+In this repository, you can find sample applications that demonstrate how to integrate the Wowza Flowplayer using our Android SDK into your Android projects. The latest version of the SDK is v2.0. For additional information and our official documentation, see the following links:
 
-The latest SDK version is: 
+* [About the Android SDK](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/about-the-android-sdk/)
+* [Get started](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/get-started-with-the-android-sdk/)
+* [Set up the player](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/set-up-the-player/)
+* [Listen for events](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/listen-for-events/)
+* [Manage the player](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/manage-the-player/)
+* [Handle errors](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/handle-errors/)
+* [Supported features](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/supported-features/)
+* [Migration guides](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/migration-guides/migrate-from-legacy-to-2.0/)
 
-[ ![Download](https://api.bintray.com/packages/flowplayer/maven/flowplayer-core/images/download.svg) ](https://bintray.com/flowplayer/maven/flowplayer-core/_latestVersion)
+## Before you start
 
-Please make sure you have updated your access token inside the `AndroidManifest.xml`, in order to be able to play videos:
-```
-<meta-data
-    android:name="com.flowplayer.accessToken"
-    android:value="YOU_ACCESS_TOKEN"/>
-```
+We assume you understand Android development and are familiar with Android Studio and Gradle. To work with the Android SDK, install Android Studio Giraffe. You can use other tools to build your application, but we rely on Android Studio to demonstrate how to work with the demo application.
 
-If you found any issues or you have any questions, please report them at the issue tracker of this repository.
+## Run the demo application
+
+If you need additional information about running the demo application in this repository, see our [official documentation](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/about-the-android-sdk/#run-the-demo-application).
+
+## Support
+
+For questions or suggestions for improvements to the Android SDK, submit an issue in this repository. You can also submit a support ticket to <support@flowplayer.com>.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # About
 
-In this repository, you can find sample applications that demonstrate how to integrate the Wowza Flowplayer using our Android SDK into your Android projects. The latest version of the SDK is v2.0. For additional information and our official documentation, see the following links:
+In this repository, you can find sample applications that demonstrate how to integrate the Wowza Flowplayer into your Android projects using our Android SDK. The latest version of the SDK is v2.0. For additional information and our official documentation, see the following links:
 
 * [About the Android SDK](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/about-the-android-sdk/)
 * [Get started](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/get-started-with-the-android-sdk/)
@@ -17,7 +17,7 @@ We assume you understand Android development and are familiar with Android Studi
 
 ## Run the demo application
 
-If you need additional information about running the demo application in this repository, see our [official documentation](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/about-the-android-sdk/#run-the-demo-application).
+If you need additional information to run the demo application, see our [official documentation](https://developer.wowza.com/docs/wowza-flowplayer/android-sdk/about-the-android-sdk/#run-the-demo-application).
 
 ## Support
 


### PR DESCRIPTION
Updating the readme for the Android SDK demo repository. For these two issues:

* https://wowza.tpondemand.com/entity/66503-playback-review-readme-files-in-repos (TP)
* https://wowzamedia.jira.com/browse/PLAY-34 (Jira)

@VikiBDev I mostly linked to the official docs here, so we don't have to maintain content in more than one place. But open to suggestions if that doesn't work. We probably shouldn't merge this into `master` until the official Android SDK docs are released.